### PR TITLE
Feature: Hold sneak to split the amount of time to go through the portal in half

### DIFF
--- a/src/main/java/com/simplystacked/CommonConfig.java
+++ b/src/main/java/com/simplystacked/CommonConfig.java
@@ -9,6 +9,8 @@ public class CommonConfig {
 
 	public static final ForgeConfigSpec.IntValue TELEPORT_COOLDOWN;
 
+	public static final ForgeConfigSpec.BooleanValue ALLOW_SNEAK;
+
 	static {
 		ForgeConfigSpec.Builder commonBuilder = new ForgeConfigSpec.Builder();
 
@@ -16,6 +18,10 @@ public class CommonConfig {
 		TELEPORT_COOLDOWN = commonBuilder.comment("How long in ticks before the entity can teleport again").defineInRange("cooldown", 60, 0, Integer.MAX_VALUE);
 		commonBuilder.pop();
 
+		commonBuilder.push("Allow Sneak");
+		ALLOW_SNEAK = commonBuilder.comment("Whether sneaking doubles the amount of time it takes to switch dimensions").define("allow_sneak", true);
+		commonBuilder.pop();
+		
 		COMMONCONFIG = commonBuilder.build();
 	}
 }

--- a/src/main/java/com/simplystacked/CommonConfig.java
+++ b/src/main/java/com/simplystacked/CommonConfig.java
@@ -16,9 +16,6 @@ public class CommonConfig {
 
 		commonBuilder.push("Teleporting");
 		TELEPORT_COOLDOWN = commonBuilder.comment("How long in ticks before the entity can teleport again").defineInRange("cooldown", 60, 0, Integer.MAX_VALUE);
-		commonBuilder.pop();
-
-		commonBuilder.push("Allow Sneak");
 		ALLOW_SNEAK = commonBuilder.comment("Whether sneaking halves the amount of time it takes to switch dimensions").define("allow_sneak", true);
 		commonBuilder.pop();
 

--- a/src/main/java/com/simplystacked/CommonConfig.java
+++ b/src/main/java/com/simplystacked/CommonConfig.java
@@ -19,9 +19,9 @@ public class CommonConfig {
 		commonBuilder.pop();
 
 		commonBuilder.push("Allow Sneak");
-		ALLOW_SNEAK = commonBuilder.comment("Whether sneaking doubles the amount of time it takes to switch dimensions").define("allow_sneak", true);
+		ALLOW_SNEAK = commonBuilder.comment("Whether sneaking halves the amount of time it takes to switch dimensions").define("allow_sneak", true);
 		commonBuilder.pop();
-		
+
 		COMMONCONFIG = commonBuilder.build();
 	}
 }

--- a/src/main/java/com/simplystacked/Teleporting/TeleportHandler.java
+++ b/src/main/java/com/simplystacked/Teleporting/TeleportHandler.java
@@ -14,8 +14,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.event.entity.living.LivingEvent;
 
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 import java.util.UUID;
 
 public class TeleportHandler {
@@ -30,14 +28,7 @@ public class TeleportHandler {
             return;
         }
 
-        //updateCooldownCache();
-        int amountToLower = 1;
-
-        if (CommonConfig.ALLOW_SNEAK.get() && entity.isShiftKeyDown()) {
-            amountToLower = 2;
-        }
-
-        updatePlayerCooldownCache(entity.getUUID(), amountToLower);
+        updateCooldownCache(entity);
 
         if (!entity.canChangeDimensions()) {
             return;
@@ -85,27 +76,19 @@ public class TeleportHandler {
     }
 
     /**
-     * Updates all entries in the cooldown cache. Decrements the cooldown value. Removes entries with 0 cooldown.
+     * Updates given entity in the cooldown cache. Decrements the cooldown value. Removes entries with 0 cooldown.
      */
-    private static void updateCooldownCache() {
-        Iterator<Map.Entry<UUID, Integer>> it = cooldownCache.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<UUID, Integer> entry = it.next();
-            int value = entry.getValue() - 1;
-            if (value <= 0) {
-                it.remove();
-        for (Map.Entry<UUID, Integer> entry : cooldownCache.entrySet()) {
-            updatePlayerCooldownCache(entry.getKey(),1);
+    private static void updateCooldownCache(LivingEntity entity) {
+        UUID uuid = entity.getUUID();
+        int amountToLower = 1;
+        if (CommonConfig.ALLOW_SNEAK.get() && entity.isShiftKeyDown()) {
+            amountToLower = 2;
         }
-    }
-
-    private static void updatePlayerCooldownCache(UUID uuid, int amountToLower) {
         if (cooldownCache.containsKey(uuid)) {
             int val = cooldownCache.getOrDefault(uuid, 0);
             if (val <= 0) {
-               cooldownCache.remove(uuid);
+                cooldownCache.remove(uuid);
             } else {
-                entry.setValue(value);
                 cooldownCache.put(uuid, val - amountToLower);
             }
         }

--- a/src/main/java/com/simplystacked/Teleporting/TeleportHandler.java
+++ b/src/main/java/com/simplystacked/Teleporting/TeleportHandler.java
@@ -29,7 +29,14 @@ public class TeleportHandler {
             return;
         }
 
-        updateCooldownCache();
+        //updateCooldownCache();
+        int amountToLower = 1;
+
+        if (CommonConfig.ALLOW_SNEAK.get() && entity.isShiftKeyDown()) {
+            amountToLower = 2;
+        }
+
+        updatePlayerCooldownCache(entity.getUUID(), amountToLower);
 
         if (!entity.canChangeDimensions()) {
             return;
@@ -81,10 +88,17 @@ public class TeleportHandler {
      */
     private static void updateCooldownCache() {
         for (Map.Entry<UUID, Integer> entry : cooldownCache.entrySet()) {
-            if (entry.getValue() <= 0) {
-                cooldownCache.remove(entry.getKey());
+            updatePlayerCooldownCache(entry.getKey(),1);
+        }
+    }
+
+    private static void updatePlayerCooldownCache(UUID uuid, int amountToLower) {
+        if (cooldownCache.containsKey(uuid)) {
+            int val = cooldownCache.getOrDefault(uuid, 0);
+            if (val <= 0) {
+               cooldownCache.remove(uuid);
             } else {
-                cooldownCache.put(entry.getKey(), entry.getValue() - 1);
+                cooldownCache.put(uuid, val - amountToLower);
             }
         }
     }


### PR DESCRIPTION
I've been playing a modpack that uses this mod to travel to the modpack's version of the nether, but it is configured to take about 30 seconds to travel between dimensions. This addition would allow for a configuration to be made that will split the amount of time it takes to travel in half by subtracting the cooldown by two when the player is sneaking.

I think it could be a handy feature for those who would like it, but allowing for the option for the way it previously worked to also take affect by keeping the configuration's default setting to `false`.